### PR TITLE
(Fix) Increases default storage to 100GB

### DIFF
--- a/main/variables.tf
+++ b/main/variables.tf
@@ -66,7 +66,7 @@ variable "db_password" {
 
 variable "db_storage" {
   description = "The database storage size in GB"
-  default     = "20"
+  default     = "100"
 }
 
 variable "db_storage_type" {


### PR DESCRIPTION
Resolves #28 

Ethereum Mainnet will require much larger storage. We will need to adjust when we are ready for testing.