### PR TITLE
Install gcc to compile NIFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The bootstrap script included in this project expects the AWS CLI, jq, and Terraform to be installed and on the PATH.
 
-On macOS, with Homebrew installed, just run: `brew install awscli jq terraform`
+On macOS, with Homebrew installed, just run: `brew install --with-default-names awscli gnu-sed jq terraform`
 
 For other platforms, or if you don't have Homebrew installed, please see the following links:
 
@@ -22,9 +22,9 @@ You will also need the following information for the installer:
 ## AWS
 
 You will need to set up a new AWS account (or subaccount), and then either login
-to that account using the AWS CLI (via `aws configure`) or create a user account 
-that you will use for provisioning, and login to that account. The account used 
-requires full access to all AWS services, as a wide variety of services are used, 
+to that account using the AWS CLI (via `aws configure`) or create a user account
+that you will use for provisioning, and login to that account. The account used
+requires full access to all AWS services, as a wide variety of services are used,
 a mostly complete list is as follows:
 
 - VPCs and associated networking resources (subnets, routing tables, etc.)

--- a/bin/infra
+++ b/bin/infra
@@ -236,7 +236,7 @@ function destroy() {
 function provision() {
     # If INFRA_PREFIX has not been set yet, request it from user
     if [ -z "$INFRA_PREFIX" ]; then
-        DEFAULT_INFRA_PREFIX=$(tr -dc 'a-z0-9' < /dev/urandom | fold -w 5 | head -n 1)
+        DEFAULT_INFRA_PREFIX=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 5 | head -n 1)
 
         warnb << EOF
 # Infrastructure Prefix

--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -184,6 +184,10 @@ if [ "$(has_db)" != "1" ]; then
         -c "CREATE DATABASE $DB_NAME;" >"$LOG"
 fi
 
+log "Installing gcc for NIF compilation during code deploy"
+
+yum install -y --enablerepo=epel gcc  >"$LOG"
+
 log "Application environment is ready!"
 
 log "Starting CodeDeploy agent.."


### PR DESCRIPTION
Fixes poanetwork/poa-explorer#323

## Changelog
### Bug Fixes
* Install `gcc` to compile NIFs, such as `bcrypt`, during CodeDeploy
* macOS compatibility fixes
  * GNU sed is needed on macoS to make `r` option work.
  * `LC_ALL=c` to make `tr` work on binary ouput to generate random prefix.