### PR TITLE
(Fix) Change SECRET_KEY_BASE to 64 char

### DIFF
--- a/bin/infra
+++ b/bin/infra
@@ -295,7 +295,7 @@ EOF
     if [ -z "$SECRET_KEY_BASE" ]; then
         SECRET_KEY_BASE="$(get_config 'secret_key_base')"
         if [ -z "$SECRET_KEY_BASE" ]; then
-            SECRET_KEY_BASE="$(openssl rand -base64 32)"
+            SECRET_KEY_BASE="$(openssl rand -base64 64)"
         fi
     fi
 


### PR DESCRIPTION
Fixes #38

`prod.secret.exs` requires a 64 character string. The previous 32 character string created an error while trying to navigate to the contract verification page.