### PR TITLE
Install Libtool in build script

### DIFF
--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -59,6 +59,10 @@ if ! which git >/dev/null; then
     log "Installing git.."
     yum install -y --enablerepo=epel git >"$LOG"
 fi
+if ! which libtool >/dev/null; then
+    log "Installing libtool.."
+    yum install -y libtool >"$LOG"
+fi
 
 log "Determining region this instance is in.."
 REGION="$(curl -s $DYNDATA_URL/instance-identity/document | jq -r '.region')"


### PR DESCRIPTION
Fixes #40

With the merge of the read contract functionality `libtoolize` was needed  for one of the dependencies. After testing the fix, I was able to successfully complete the deployment.

Here is the temporary build with this fix: http://sokab-explorer-sokol-elb-1771258833.us-east-1.elb.amazonaws.com/en