### PR TITLE
Add 'node' as global dependency

### DIFF
--- a/modules/stack/libexec/init.sh
+++ b/modules/stack/libexec/init.sh
@@ -63,6 +63,11 @@ if ! which libtool >/dev/null; then
     log "Installing libtool.."
     yum install -y libtool >"$LOG"
 fi
+if ! which node >/dev/null; then
+    log "Installing nodejs.."
+    yum --enablerepo=epel install -y nodejs >"$LOG"
+fi
+
 
 log "Determining region this instance is in.."
 REGION="$(curl -s $DYNDATA_URL/instance-identity/document | jq -r '.region')"


### PR DESCRIPTION
Resolves #37

The "Verify Smart Contract" feature depends on `node` to be installed in the machine because we use the node lib `solc-js` to compile the smart contract code source.

This PR adds the `node` dependency as a global one in the `init.sh` file.